### PR TITLE
RNMT-1746 Revert previous release

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -120,8 +120,8 @@
 		<source-file src="src/android/src/com/pushwoosh/plugin/pushnotifications/NotificationFactory.java"
 						target-dir="src/com/pushwoosh/plugin/pushnotifications" />
 
-		<framework src="com.google.android.gms:play-services-gcm:12.+" />
-		<framework src="com.google.android.gms:play-services-location:12.+" />
+		<framework src="com.google.android.gms:play-services-gcm:+" />
+		<framework src="com.google.android.gms:play-services-location:+" />
 		<framework src="com.android.support:support-v4:25.+" />
 		<framework src="com.pushwoosh:pushwoosh:4.12.2" />
 		<framework src="push.gradle" custom="true" type="gradleReference" />


### PR DESCRIPTION
Locking to version 12 actually brought lots of conflicts with other plugins. We had to go to 12 because *we thought* that being in the latest was the issue, but we were affected by two other issues: JCenter not having the repositories and then returning corrupted binaries. Those were the real issues. By downgrading, we caused more conflicts.

Foot note: We should revisit this "+" in all plugins. Not locking has benefits, but it also has disadvantages.