### PR TITLE
RNMT-1741 (Android) Add Google Play Services Ads library

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -122,6 +122,7 @@
 
 		<framework src="com.google.android.gms:play-services-gcm:+" />
 		<framework src="com.google.android.gms:play-services-location:+" />
+		<framework src="com.google.android.gms:play-services-ads:+" />
 		<framework src="com.android.support:support-v4:25.+" />
 		<framework src="com.pushwoosh:pushwoosh:4.12.2" />
 		<framework src="push.gradle" custom="true" type="gradleReference" />


### PR DESCRIPTION
Adding the Google Maven repository to the Native Shell caused the
Google Play Services libraries to resolve to newer versions than
when just using mavenCentral/jcenter, which are not supported in this
Pushwoosh version. Upstream has fixed this in recent versions but
at the time of this writting it is not possible to merge upstream
changes due to MABS not targeting Android O. This workaround allows
Pushwoosh to continue working with the Google Maven repository.