### PR TITLE
RNMT-2091 Fix OnInitializeOver event not being triggered

### DIFF
--- a/src/android/src/com/pushwoosh/plugin/pushnotifications/PushNotifications.java
+++ b/src/android/src/com/pushwoosh/plugin/pushnotifications/PushNotifications.java
@@ -165,6 +165,8 @@ public class PushNotifications extends CordovaPlugin {
 			PWLog.error(TAG, "Missing pw_appid parameter. Did you follow the guide correctly?", e);
 			return false;
 		}
+		
+		callbackContext.success();
 		return true;
 	}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
OnDevice ready event must trigger a callback result in order to finish the OnInitializeOver event. This is a custom implementation of our version, this is needed to trigger the event OnInitializeOver properly. This change was lost on merge for the latest version of the plugin.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
https://outsystemsrd.atlassian.net/browse/RNMT-2091

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Platforms affected
- [x] Android
- [ ] iOS

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested with Sample app where the issue was reproduced.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
    - [ ] Documentation has been updated accordingly