### PR TITLE
RNMT-2972 PushWoosh Plugin is not compatible with other plugins that use Firebase

### DIFF
--- a/libs/android/googleservices-build.gradle
+++ b/libs/android/googleservices-build.gradle
@@ -1,0 +1,23 @@
+buildscript {
+    repositories {
+        jcenter()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:+'
+        classpath 'com.google.gms:google-services:4.0.2'
+    }
+}
+
+// use postBuildExtras to make sure the plugin is applied after
+// cdvPluginPostBuildExtras. Therefore if googleServices is added
+// to cdvPluginPostBuildExtras somewhere else, the plugin execution
+// will be skipped and project build will be successfull
+ext.postBuildExtras = {
+    if (project.extensions.findByName('googleServices') == null) {
+        // apply plugin: 'com.google.gms.google-services'
+        // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
+        apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+    }
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -28,8 +28,6 @@
 	<platform name="android">
 		<hook type="before_plugin_install" src="hooks/outsystems/handle_google_services.js" />
 		<hook type="after_plugin_install" src="hooks/outsystems/google_services_cleanup.js" />
-
-		<dependency id="cordova-support-google-services" version="1.3.1" />
 	
 		<config-file>
 			<access origin="*.pushwoosh.com" />
@@ -77,6 +75,8 @@
 		<framework src="com.pushwoosh:pushwoosh-badge:5.13.0"/>
         <framework src="com.pushwoosh:pushwoosh-inbox:5.13.0"/>
         <framework src="com.pushwoosh:pushwoosh-inbox-ui:5.13.0"/>
+
+		<framework src="libs/android/googleservices-build.gradle" custom="true" type="gradleReference" />
 	</platform>
 
 	<!-- ios -->


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Reverted version of google-services to 4.0.2.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes https://outsystemsrd.atlassian.net/browse/RNMT-2972

<!--- Why is this change required? What problem does it solve? -->
Updating the version of the cordova-support-google-services plugin caused an issue in MABS 4. It was using version 4.2.0 of the google-services plugin. This version has issues when the plugin is applied in the top-level project, which is exactly what happens with cordova-android 6.4.0 and therefore MABS 4.

To fix this we needed to change the version. To achieve this we either fork the plugin or add the only relevant file of the plugin to the project. This commit implements the latter approach.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manual tests were performed.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly