### PR TITLE
RNMT-3266 Dynamically select dependency version

### DIFF
--- a/libs/android/googleservices-build.gradle
+++ b/libs/android/googleservices-build.gradle
@@ -10,6 +10,34 @@ buildscript {
     }
 }
 
+String getVersion() {
+  def compileSdkVersion = Integer.parseInt(project.android.compileSdkVersion.split("-")[1])
+  return compileSdkVersion >= 28 ? "28.0.0" : "27.+" 
+}
+
+// Defer the definition of the dependencies to the end
+// of the "configuration" phase from the app build.gradle file
+// so that we can inquire the proper compile sdk version being used.
+cdvPluginPostBuildExtras.push({
+  dependencies {
+    def supportVersion = getVersion()
+    implementation "com.google.firebase:firebase-core:16.0.4"
+    implementation "com.google.firebase:firebase-messaging:17.3.4"
+    implementation "com.android.support:support-v4:${supportVersion}"
+    implementation "com.android.support:appcompat-v7:${supportVersion}"
+    implementation "com.android.support:recyclerview-v7:${supportVersion}"
+    implementation "com.android.support:design:${supportVersion}"
+    implementation "com.android.support.constraint:constraint-layout:1.0.2"
+    implementation "com.github.bumptech.glide:glide:4.7.1"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:1.1.60"
+    implementation "com.pushwoosh:pushwoosh:5.17.2"
+    implementation "com.pushwoosh:pushwoosh-amazon:5.17.2"
+    implementation "com.pushwoosh:pushwoosh-badge:5.17.2"
+    implementation "com.pushwoosh:pushwoosh-inbox:5.17.2"
+    implementation "com.pushwoosh:pushwoosh-inbox-ui:5.17.2"
+  }
+})
+
 // use postBuildExtras to make sure the plugin is applied after
 // cdvPluginPostBuildExtras. Therefore if googleServices is added
 // to cdvPluginPostBuildExtras somewhere else, the plugin execution

--- a/plugin.xml
+++ b/plugin.xml
@@ -60,21 +60,6 @@
 		<source-file src="src/android/src/com/pushwoosh/plugin/internal/PhonegapPluginProvider.java"
 			target-dir="src/com/pushwoosh/plugin/internal" />
 
-		<framework src="com.google.firebase:firebase-core:16.0.4" />
-		<framework src="com.google.firebase:firebase-messaging:17.3.4" />
-
-		<framework src="com.android.support:support-v4:28.0.0" />
-        <framework src="com.android.support:appcompat-v7:28.0.0" />
-        <framework src="com.android.support:recyclerview-v7:28.0.0" />
-        <framework src="com.android.support:design:28.0.0" />
-        <framework src="com.android.support.constraint:constraint-layout:1.0.2" />
-        <framework src="com.github.bumptech.glide:glide:4.7.1" />
-        <framework src="org.jetbrains.kotlin:kotlin-stdlib-jre7:1.1.60" />
-        <framework src="com.pushwoosh:pushwoosh:5.17.2"/>
-		<framework src="com.pushwoosh:pushwoosh-amazon:5.17.2"/>
-		<framework src="com.pushwoosh:pushwoosh-badge:5.17.2"/>
-        <framework src="com.pushwoosh:pushwoosh-inbox:5.17.2"/>
-        <framework src="com.pushwoosh:pushwoosh-inbox-ui:5.17.2"/>
 		<framework src="libs/android/googleservices-build.gradle" custom="true" type="gradleReference" />
 	</platform>
 


### PR DESCRIPTION
This PR adds the ability for the plugin to pick and chose, in build time, which is the appropriate support library version that must be used depending on the compileSdkVersion (and indirectly the MABS version) in use.

References https://outsystemsrd.atlassian.net/browse/RNMT-3266